### PR TITLE
feat: encrypt/decrypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pillow
 youtube-dl
 # youtube-upload
 git+https://github.com/tokland/youtube-upload.git
+PyCryptodome==3.17.0

--- a/youtube_drive/config.py
+++ b/youtube_drive/config.py
@@ -1,1 +1,2 @@
+enable_encryption = False
 encryption_key = 'DefaultEncryptionKey'

--- a/youtube_drive/keys.py
+++ b/youtube_drive/keys.py
@@ -1,0 +1,1 @@
+encryption_key = 'DefaultEncryptionKey'

--- a/youtube_drive/main.py
+++ b/youtube_drive/main.py
@@ -132,7 +132,7 @@ def main(args):
                                action='store_true',
                                default=False,
                                help='decrypt the file')
-    encode_parser.add_argument('--key',
+    decode_parser.add_argument('--key',
                                 action='store',
                                 metavar="decryption_key",
                                 default=None,

--- a/youtube_drive/main.py
+++ b/youtube_drive/main.py
@@ -80,10 +80,14 @@ def cmd_retrieve(args):
 
 
 def cmd_encode(args):
+    if args.encrypt and args.key is not None:
+        args.key = str(args.key).encode("ascii")[:16]
     youtube_codec.encode(args.i, args.video_filename, args.video_fps, args.encrypt, args.key)
 
 
 def cmd_decode(args):
+    if args.decrypt and args.key is not None:
+        args.key = str(args.key).encode("ascii")[:16]
     youtube_codec.decode(args.i, args.filename, args.decrypt, args.key)
 
 

--- a/youtube_drive/main.py
+++ b/youtube_drive/main.py
@@ -80,11 +80,11 @@ def cmd_retrieve(args):
 
 
 def cmd_encode(args):
-    youtube_codec.encode(args.i, args.video_filename, args.video_fps)
+    youtube_codec.encode(args.i, args.video_filename, args.video_fps, args.encrypt, args.key)
 
 
 def cmd_decode(args):
-    youtube_codec.decode(args.i, args.filename)
+    youtube_codec.decode(args.i, args.filename, args.decrypt, args.key)
 
 
 def main(args):
@@ -105,6 +105,15 @@ def main(args):
     encode_parser.add_argument('video_filename',
                                action='store',
                                help='save the video to this filename')
+    encode_parser.add_argument('--encrypt',
+                                action='store_true',
+                                default=False,
+                                help='encrypt the file')
+    encode_parser.add_argument('--key',
+                                action='store',
+                                metavar="encryption_key",
+                                default=None,
+                                help='encryption key')
     encode_parser.set_defaults(handle=cmd_encode)
 
     decode_parser = subparsers.add_parser('decode', aliases=['de'], help='decode a video to a file')
@@ -115,6 +124,15 @@ def main(args):
     decode_parser.add_argument('filename',
                                action='store',
                                help='Save the output file to this filename')
+    decode_parser.add_argument('--decrypt',
+                               action='store_true',
+                               default=False,
+                               help='decrypt the file')
+    encode_parser.add_argument('--key',
+                                action='store',
+                                metavar="decryption_key",
+                                default=None,
+                                help='decryption key')
     decode_parser.set_defaults(handle=cmd_decode)
 
     upload_parser = subparsers.add_parser('upload', aliases=['up'], help='upload a file to YouTube')

--- a/youtube_drive/youtube_codec.py
+++ b/youtube_drive/youtube_codec.py
@@ -29,13 +29,9 @@ def encrypt_data_aes(data: bytes, key: bytes) -> bytes:
 
 
 def decrypt_data_aes(data: bytes, key: bytes) -> bytes:
-    # Base 64 decode the result
     raw = base64.urlsafe_b64decode(data)
-
-    # Extract 16 byte initialization vector
     nonce, tag, ciphertext = raw[:16], raw[16:32], raw[32:]
 
-    # Decrypt text with user's secret key (256 bit AES/CBC/PKCS5Padding) and initialization vector
     cipher = AES.new(key, AES.MODE_EAX, nonce)
     clear_data = cipher.decrypt_and_verify(ciphertext, tag)
     return clear_data

--- a/youtube_drive/youtube_codec.py
+++ b/youtube_drive/youtube_codec.py
@@ -4,7 +4,7 @@ import cv2
 
 import base64
 from Crypto.Cipher import AES
-import config
+from . import config
 
 ENABLE_ENCRYPTION = getattr(config, 'enable_encryption', False)
 KEY = getattr(config, 'encryption_key', 'DefaultEncryptionKey').encode("ascii")[:16]


### PR DESCRIPTION
Feature:
Allow optional encrypt/decrypt step while encoding/decoding video and file data.
By default it's not enabled to achieve compatibility with old versions of releases.
I use AES as the crytpo algorithm and follow the code example here: https://pycryptodome.readthedocs.io/en/latest/src/cipher/aes.html
The video file will be 30% bigger after enabling encryption (too big 😿, even snappy.compress can't help)

User interface:
There're two flags for this feature:
1. enable_encryption: it's false by default, if you set it to be true, encrypt/decrypt step will be enabled during encoding/decoding
2. encryption_key: it's a user-defined private key, need to be longer than 16 bytes.

User can change these configurations through config file or command line. 
The value passed by command line has a higher priority.

Anything else:
fix two bugs: 
1. encode func, add the case that num_leftover_bytes == 0
2. decode func, data_bytes_retrieved = data_bytes[4:len_of_data+4] , fixing the upperbound. It should be len_of_data+4 or you'll miss the last 4 bytes of data.

Todo: 
- update README

